### PR TITLE
 修正 DLFiexedTabbarView 的 trackView_ 布局

### DIFF
--- a/DLSlideView/DLTabbarView/DLFixedTabbarView.m
+++ b/DLSlideView/DLTabbarView/DLFixedTabbarView.m
@@ -110,7 +110,7 @@
     [self layoutTabbar];
 }
 
-- (void)layoutTabbar{
+- (void)layoutTabbar {
     float width = self.bounds.size.width/self.tabbarItems.count;
     float height = self.bounds.size.height;
     float x = 0.0f;
@@ -125,7 +125,7 @@
     }
     
     float trackX = width*self.selectedIndex;
-    trackView_.frame = CGRectMake(trackX, trackView_.frame.origin.y, width, kTrackViewHeight);
+    trackView_.frame = CGRectMake(trackX, self.bounds.size.height-kTrackViewHeight-1, width, kTrackViewHeight);
 }
 
 - (NSInteger)tabbarCount{


### PR DESCRIPTION
修正 DLFiexedTabbarView 的 trackView_ 布局，以解决设置 tabbarHeight 后，trackView 依然在 tab item label 的下面，而不是 tab bar 的最底部。

修改前：
![](https://ws1.sinaimg.cn/large/006tKfTcgy1fmo7xfh981j30fu02wmxb.jpg)

修改后：
![](https://ws4.sinaimg.cn/large/006tKfTcgy1fmo7xnua8vj30fs032wen.jpg)